### PR TITLE
diag(dsp1/mode7): instrumentacao temporaria do caminho DSP-1 -> HDMA …

### DIFF
--- a/src/snes/core/sndbglog.h
+++ b/src/snes/core/sndbglog.h
@@ -1,0 +1,52 @@
+/*
+ * sndbglog.h - Instrumentacao TEMPORARIA de diagnostico do caminho
+ *              DSP-1 -> HDMA -> Mode-7 (registradores M7A-M7D).
+ *
+ *  Objetivo: descobrir POR QUE a pista do Super Mario Kart aparece
+ *  achatada (matriz Mode-7 constante por scanline).
+ *
+ *  Saida via ConDebug (=printf), capturada no logs.txt do NetherSX2.
+ *
+ *  Throttle: imprime apenas 1 "snapshot" a cada SNDBG_FRAME_PERIOD
+ *  frames (~5s @60fps) e limita o volume do dump do DSP por frame,
+ *  para nao explodir o log.
+ *
+ *  >>> REMOVER (ou definir SNDBG_LOG 0) antes de release. <<<
+ */
+#ifndef _SNDBGLOG_H
+#define _SNDBGLOG_H
+
+#include "types.h"
+#include "console.h"
+
+// liga/desliga toda a instrumentacao de uma vez
+#define SNDBG_LOG 1
+
+// 1 snapshot a cada N frames (300 = ~5 segundos)
+#define SNDBG_FRAME_PERIOD 300
+// quantos acessos ao DSP logar por frame de snapshot (cap)
+#define SNDBG_DSP_MAXLOG   80
+
+#if SNDBG_LOG
+
+// definidos em snes.cpp
+extern int g_SnesDbgFrame;   // frame atual
+extern int g_SnesDbgLine;    // scanline atual
+extern int g_SnesDbgDspN;    // contador de acessos DSP no frame (reset por frame)
+
+// true no frame de snapshot
+static inline int SnesDbgWin(void)
+{
+	return (g_SnesDbgFrame >= 0) && ((g_SnesDbgFrame % SNDBG_FRAME_PERIOD) == 0);
+}
+
+#define SNDBG(...)        do { if (SnesDbgWin()) ConDebug(__VA_ARGS__); } while (0)
+
+#else
+
+static inline int SnesDbgWin(void) { return 0; }
+#define SNDBG(...)        do {} while (0)
+
+#endif // SNDBG_LOG
+
+#endif // _SNDBGLOG_H

--- a/src/snes/core/sndma.cpp
+++ b/src/snes/core/sndma.cpp
@@ -11,6 +11,7 @@ extern "C" {
 };
 #include "sndma.h"
 #include "snppu.h"
+#include "sndbglog.h"
 
 #define SNESDMA_DEBUG 0
 
@@ -535,6 +536,28 @@ void SnesDMAC::ProcessMDMAChFast(Uint32 uChan)
 void SnesDMAC::BeginHDMA()
 {
 	Uint8 uEnabled = m_HDMAEnable;
+
+#if SNDBG_LOG
+	if (SnesDbgWin())
+	{
+		ConDebug("HDMA enable=%02X\n", m_HDMAEnable);
+		for (Uint32 c=0; c < SNESDMAC_CHANNEL_NUM; c++)
+		{
+			if (!(m_HDMAEnable & (1<<c))) continue;
+			SnesDMAChT *p = &m_Channels[c];
+			Uint8 mode    = p->dmapx & 7;
+			Uint8 indirect= (p->dmapx & 0x40) ? 1 : 0;
+			Uint8 dir     = (p->dmapx & 0x80) ? 1 : 0; // 1 = B->A (read from PPU)
+			Uint32 bbus   = 0x2100 + p->bbadx;
+			// destaca canais que escrevem na matriz Mode-7 (M7A..M7D = $211B..$211E)
+			const char *tag = (p->bbadx >= 0x1B && p->bbadx <= 0x1E) ? "  <== MODE7 M7A-D" :
+			                  (p->bbadx >= 0x1F && p->bbadx <= 0x20) ? "  <== MODE7 M7X/Y" : "";
+			ConDebug("  HDMA%d dmap=%02X mode=%d indir=%d dir=%d Bbus=%04X table=%02X:%04X iBank=%02X%s\n",
+				(int)c, p->dmapx, mode, indirect, dir, bbus,
+				p->a1bx, p->a1tx, p->dasbx, tag);
+		}
+	}
+#endif
 
 	for (Uint32 uChan=0; uChan < SNESDMAC_CHANNEL_NUM; uChan++)
 	{

--- a/src/snes/core/snes.cpp
+++ b/src/snes/core/snes.cpp
@@ -9,6 +9,12 @@
 #include "prof.h"
 #include "sntiming.h"
 #include "sndebug.h"
+#include "sndbglog.h"
+
+// --- diagnostico DSP-1 -> HDMA -> Mode-7 (ver sndbglog.h) ---
+int g_SnesDbgFrame = -1;
+int g_SnesDbgLine  = 0;
+int g_SnesDbgDspN  = 0;
 
 
 #define SNES_SYNCPPUEVERYLINE (CODE_DEBUG && 0) 
@@ -647,11 +653,25 @@ Uint8 SNCPU_TRAPFUNC SnesSystem::ReadDSP1(SNCpuT *pCpu, Uint32 uAddr)
 	case 0x6000:
 	case 0x8000:
 	case 0xA000:
-		return pSnes->m_pDsp->ReadData(uAddr);
+		{
+			Uint8 d = pSnes->m_pDsp->ReadData(uAddr);
+#if SNDBG_LOG
+			if (SnesDbgWin() && g_SnesDbgDspN < SNDBG_DSP_MAXLOG)
+			{ ConDebug("DSP RD DR  [%06X]=%02X (f%d l%d)\n", uAddr, d, g_SnesDbgFrame, g_SnesDbgLine); g_SnesDbgDspN++; }
+#endif
+			return d;
+		}
 	case 0x7000:
 	case 0xC000:
 	case 0xE000:
-		return pSnes->m_pDsp->ReadStatus(uAddr);
+		{
+			Uint8 s = pSnes->m_pDsp->ReadStatus(uAddr);
+#if SNDBG_LOG
+			if (SnesDbgWin() && g_SnesDbgDspN < SNDBG_DSP_MAXLOG)
+			{ ConDebug("DSP RD SR  [%06X]=%02X\n", uAddr, s); g_SnesDbgDspN++; }
+#endif
+			return s;
+		}
 	}
 #if SNES_DEBUG
     if (Snes_bDebugUnhandledIO)
@@ -670,6 +690,10 @@ void SNCPU_TRAPFUNC SnesSystem::WriteDSP1(SNCpuT *pCpu, Uint32 uAddr, Uint8 uDat
 	case 0x6000:
 	case 0x8000:
 	case 0xA000:
+#if SNDBG_LOG
+		if (SnesDbgWin() && g_SnesDbgDspN < SNDBG_DSP_MAXLOG)
+		{ ConDebug("DSP WR DR  [%06X]=%02X (f%d l%d)\n", uAddr, uData, g_SnesDbgFrame, g_SnesDbgLine); g_SnesDbgDspN++; }
+#endif
 		pSnes->m_pDsp->WriteData(uAddr, uData);
 		break;
 	default:
@@ -941,6 +965,7 @@ void SnesSystem::ExecuteWithIRQ(Int32 nCycles, Int32 &nIRQCycles)
 void SnesSystem::ExecuteLine()
 {
 	SNCPUResetCounter(&m_Cpu, SNCPU_COUNTER_LINE);
+	g_SnesDbgLine = (int)m_uLine;
 
     // don't trigger IRQ by default
     int nHIRQCycles = -1;
@@ -987,6 +1012,26 @@ void SnesSystem::ExecuteLine()
         m_DMAC.ProcessHDMA();
     }
 
+#if SNDBG_LOG
+	// captura a matriz Mode-7 em scanlines selecionadas: se A/B/C/D NAO
+	// variam ao longo das linhas, a pista esta achatada (matriz constante).
+	if (SnesDbgWin())
+	{
+		switch (m_uLine)
+		{
+		case 8: case 60: case 110: case 160: case 200:
+			{
+			const SnesPPURegsT *r = m_PPU.GetRegs();
+			ConDebug("M7 l%3d  A=%04X B=%04X C=%04X D=%04X  X=%04X Y=%04X sel=%02X\n",
+				(int)m_uLine,
+				r->m7a.w, r->m7b.w, r->m7c.w, r->m7d.w,
+				r->m7x.w, r->m7y.w, r->m7sel);
+			}
+			break;
+		}
+	}
+#endif
+
     // execute CPU during h-blank
     ExecuteWithIRQ(SNES_HBLANKCYCLES, nHIRQCycles);
 
@@ -1001,6 +1046,13 @@ void SnesSystem::ExecuteLine()
 void SnesSystem::ExecuteFrame(Emu::SysInputT  *pInput, CRenderSurface *pTarget, CMixBuffer *pSound, ModeE eMode)
 {
     m_uLine = 0;
+
+	// --- diagnostico Mode-7 ---
+	g_SnesDbgFrame = (int)m_uFrame;
+	g_SnesDbgLine  = 0;
+	g_SnesDbgDspN  = 0;
+	SNDBG("==== SNDBG frame %d ==== (mode7? bgmode=%02X)\n",
+		g_SnesDbgFrame, m_PPU.GetRegs()->bgmode);
 
 	m_IO.LatchInput(pInput);
 


### PR DESCRIPTION
…-> M7

Adiciona logging throttled (ConDebug/printf -> logs.txt do NetherSX2) para diagnosticar a pista achatada (matriz Mode-7 constante por scanline) em jogos com DSP-1 como Super Mario Kart:

- sndbglog.h: 1 snapshot a cada 300 frames (~5s), com cap de volume por frame.
- snes.cpp: cabecalho do frame (bgmode), fluxo de R/W do DSP (DR/SR) e captura da matriz M7A-D nas scanlines 8/60/110/160/200 (se nao variam = achatado).
- sndma.cpp: dump da config de cada canal HDMA habilitado (modo, indireto, B-bus, tabela, banco indireto), destacando canais que escrevem em M7A-D.

Temporario: definir SNDBG_LOG 0 (ou remover) antes de release.