### PR TITLE
Restore 240p video mode

### DIFF
--- a/src/common/base/font.cpp
+++ b/src/common/base/font.cpp
@@ -13,7 +13,9 @@
 extern "C" {
 #include "gs.h"
 #include "gpprim.h"
+#include "gskit_backend.h"
 #include "gpfifo.h"
+
 };
 
 #define FIXED4(_x) ((Int32)((_x)*16.0f))
@@ -101,6 +103,30 @@ static Int32 _FontDrawChar(FontCharT *pFontChar, float fX, float fY, float z1, U
     y1 = ((Uint32)FIXED4(py1)) & 0xFFFF;
 
 	GPPrimTexRectAbs(x0, y0, u0, v0, x1, y1, u1, v1, 10, uColor, 1);
+
+    /*
+     * Temporary 240p font hack:
+     * the rightmost glyph column is lost by the current rasterisation.
+     * Draw that source column over the penultimate physical column
+     * instead of extending the glyph to the right.
+     */
+    if (GPPrimGetScaleX() == 1.0f && GPPrimGetScaleY() == 1.0f)
+    {
+        Uint32 lastU0 = ((pFontChar->u1 - 1) << 4);
+        Uint32 lastU1 = (pFontChar->u1 << 4);
+
+        Uint32 lastX0 = ((Uint32)FIXED4(px1 - 1.0f)) & 0xFFFF;
+        Uint32 lastX1 = ((Uint32)FIXED4(px1)) & 0xFFFF;
+
+        GPPrimTexRectAbs(
+            lastX0, y0,
+            lastU0, v0,
+            lastX1, y1,
+            lastU1, v1,
+            10, uColor, 1
+        );
+    }
+
 
     /* advance in LOGICAL units: physical glyph width + 2px gap */
     return _FontAdvLogical(width * FONT_DRAW_SCALE + 2);

--- a/src/platform/ps2/gs/gpprim.h
+++ b/src/platform/ps2/gs/gpprim.h
@@ -3,6 +3,9 @@
 #define _GPPRIM_H
 
 #include <tamtypes.h>
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 void GPPrimRect(unsigned x1, unsigned y1, unsigned c1, unsigned x2, unsigned y2, unsigned c2, unsigned z, unsigned abe);
 void GPPrimEnableZBuf(void);
@@ -32,5 +35,7 @@ float GPPrimGetOffsetY(void);
  * same as GPPrimTexRect).  Used by the font to draw glyphs at an exact
  * integer multiple of the atlas for crisp, uniform letters. */
 void GPPrimTexRectAbs(u32 x1, u32 y1, u32 u1, u32 v1, u32 x2, u32 y2, u32 u2, u32 v2, u32 z, u32 colour, unsigned abe);
-
+#ifdef __cplusplus
+}
+#endif
 #endif

--- a/src/platform/ps2/gs/gskit_backend.c
+++ b/src/platform/ps2/gs/gskit_backend.c
@@ -34,6 +34,7 @@
 #define GS_NTSC          2
 #define GS_PAL           3
 #define GS_INTERLACE     1
+#define GS_NONINTERLACED  0
 #endif
 
 static GSGLOBAL *_pGsGlobal = NULL;
@@ -129,6 +130,23 @@ void GSK_Init(int width, int height,
         _gsk_fb_width         = 640;
         _gsk_fb_height        = 480;
         _gsk_vck              = 1;
+        break;
+
+    case GSK_VIDMODE_240P:
+        /*
+         * NTSC 256x240 progressive / PAL 256x240 inside a 288p raster.
+         *
+         * This is the native SNES/NES sample grid.  Keep the framebuffer
+         * at 256x240 so the renderer's logical 256x240 canvas remains 1:1.
+         *
+         * Progressive output requires GS_FRAME rather than GS_FIELD.
+         */
+        _pGsGlobal->Mode      = _gsk_DetectTvMode();
+        _pGsGlobal->Interlace = GS_NONINTERLACED;
+        _pGsGlobal->Field     = GS_FRAME;
+        _gsk_fb_width         = 256;
+        _gsk_fb_height        = 240;
+        _gsk_vck              = 4;
         break;
 
     case GSK_VIDMODE_480I:

--- a/src/platform/ps2/gs/gskit_backend.h
+++ b/src/platform/ps2/gs/gskit_backend.h
@@ -37,6 +37,7 @@ void GSK_Init(int width, int height,
  * Only the two interlaced outputs are supported. Keep their historical IDs
  * so existing video.cfg files remain compatible: removed IDs 0 (240p/288p)
  * and 2 (480p) are rejected and fall back to 480i when settings are loaded. */
+#define GSK_VIDMODE_240P  0   /* NTSC/PAL 256x240 progressive (CRT/AV)        */
 #define GSK_VIDMODE_480I  1   /* NTSC/PAL 640x480 interlaced source            */
 #define GSK_VIDMODE_1080I 3   /* DTV 1280x960 4:3 window in a 1080i raster     */
 

--- a/src/platform/ps2/ui/uiBrowser.cpp
+++ b/src/platform/ps2/ui/uiBrowser.cpp
@@ -7,6 +7,7 @@
 #include <stdint.h>
 #include <limits.h>
 #include <unistd.h>
+
 #define NEWLIB_PORT_AWARE          /* libera fileXio no port newlib (igual main.cpp) */
 #include <fileXio.h>
 #include <fileXio_rpc.h>   /* HDD APA: fileXioDopen/Dread (listar particoes) */
@@ -24,7 +25,8 @@
 #include "mainloop_bgm.h"
 #include "mainloop_smb.h"
 #include "mainloop_ui.h"
-
+#include "gpprim.h"
+#include "../gs/gskit_backend.h"
 extern "C" {
 #include "mcsave_ee.h"
 };
@@ -256,6 +258,10 @@ static int BrowserOpenDirectory(const Char *pPath)
    embedded ASCII-only m5x7 atlas. */
 #define BROWSER_DIR_PREFIX "> "
 #define BROWSER_DIR_SUFFIX "/"
+
+/* 240p browser alignment: move the complete File Explorer UI
+   16 logical pixels to the right. */
+#define BROWSER_240P_OFFSET_X (16.0f)
 
 /* Width of a single space in the current font, used to size the
    marquee gap. We grab it lazily once per Draw() so the cost is one
@@ -994,9 +1000,31 @@ Bool CBrowserScreen::AddEntry(const Char *pName, BrowserEntryTypeE eType, Int32 
 	return TRUE;
 }
 
+extern int g_GskVideoMode;
+
+
 
 void CBrowserScreen::Draw()
 {
+	/* In 240p the File Explorer needs a 16px horizontal correction.
+	   Preserve the transform that was active when Draw() was entered,
+	   then restore it before returning so all other screens keep
+	   their original coordinates. */
+	const Float32 browserScaleX = GPPrimGetScaleX();
+	const Float32 browserScaleY = GPPrimGetScaleY();
+	const Float32 browserOffsetX = GPPrimGetOffsetX();
+	const Float32 browserOffsetY = GPPrimGetOffsetY();
+
+	if (g_GskVideoMode == GSK_VIDMODE_240P)
+	{
+		GPPrimSetTransform(
+			browserScaleX,
+			browserScaleY,
+			browserOffsetX + BROWSER_240P_OFFSET_X,
+			browserOffsetY
+		);
+	}
+
 	Int32 iEntry;
 	Int32 vx=4, vy = 20;
 	Int32 iLine;
@@ -1394,6 +1422,17 @@ void CBrowserScreen::Draw()
 
 		m_SubMenu.Draw();
 	}
+
+	if (g_GskVideoMode == GSK_VIDMODE_240P)
+	{
+		GPPrimSetTransform(
+			browserScaleX,
+			browserScaleY,
+			browserOffsetX,
+			browserOffsetY
+		);
+	}
+
 }
 
 void CBrowserScreen::Process()

--- a/src/platform/ps2/ui/uiVideo.cpp
+++ b/src/platform/ps2/ui/uiVideo.cpp
@@ -156,11 +156,12 @@ void VideoSettingsLoad(void)
 		if (cfg.mmceenable == 1 && cfg.mx4sioenable == 1)
 			cfg.mx4sioenable = 0;
 
-		/* IDs 0 (240p/288p) and 2 (480p) existed through video.cfg v17.
-		   They are deliberately unsupported now and migrate to safe 480i;
-		   the historical IDs for 480i/1080i remain unchanged. */
-		g_GskVideoMode = (cfg.mode == GSK_VIDMODE_1080I)
-		               ? GSK_VIDMODE_1080I : GSK_VIDMODE_480I;
+		if (cfg.mode == GSK_VIDMODE_240P ||
+		    cfg.mode == GSK_VIDMODE_480I ||
+		    cfg.mode == GSK_VIDMODE_1080I)
+			g_GskVideoMode = cfg.mode;
+		else
+			g_GskVideoMode = GSK_VIDMODE_480I;
 
 		if (cfg.offx >= -64 && cfg.offx <= 64) g_GskDispOffX = cfg.offx;
 		if (cfg.offy >= -64 && cfg.offy <= 64) g_GskDispOffY = cfg.offy;
@@ -253,6 +254,7 @@ typedef struct
 
 static const VideoModeChoiceT _VideoModes[] =
 {
+	{ GSK_VIDMODE_240P,  "240p/288p (CRT)" },
 	{ GSK_VIDMODE_480I,  "480i (default)" },
 	{ GSK_VIDMODE_1080I, "1080i" }
 };


### PR DESCRIPTION
This PR restores the 240p/288p CRT video mode that was removed in `f70a36f`.

The implementation is intentionally minimal and preserves the current video implementation and subsequent changes. **It restores the native 256x240 progressive framebuffer, the corresponding GS configuration, and the 240p/288p option in the video settings.**

After restoring 240p, I also added a **16px horizontal display offset to the File Explorer/menu in 240p only**, to compensate for CRT overscan and improve its positioning.

I also added a **quick experimental font-rendering workaround for 240p**. It does not make the font perfect, but it makes it noticeably more legible than the original 240p rendering. This is intended as a temporary workaround rather than a definitive fix for the underlying font-rendering issue.

Keep in mind **this is AI-assisted programming** but it has been **fully tested.**

No 480p code has been restored as part of this change.

Tested on real PS2 hardware with a CRT.

Related to #34.